### PR TITLE
set min date as last cycle date of pay run

### DIFF
--- a/components/Pages/Payruns/CreatePayRunModal/AdHocAndReleases.js
+++ b/components/Pages/Payruns/CreatePayRunModal/AdHocAndReleases.js
@@ -81,7 +81,7 @@ export const AdHocAndReleases = ({ createPayrun, isLoading, onClose }) => {
                 date={field.value ? new Date(field.value) : null}
                 setDate={field.onChange}
                 {...field}
-                minDate={lastCycleDate && addDays(new Date(lastCycleDate), 1)}
+                minDate={lastCycleDate && new Date(lastCycleDate)}
                 floatingCalendar
                 calendarStylePosition={{ top: -132, left: 32 }}
                 hasClearButton


### PR DESCRIPTION
## Changes

- Adhoc Payrun should support current date

Task [Implement Adhoc Payrun current date](https://app.clickup.com/t/1z9wm69)